### PR TITLE
Update RestService.java

### DIFF
--- a/dexter-webapp/src/main/java/it/cnr/isti/hpc/dexter/rest/RestService.java
+++ b/dexter-webapp/src/main/java/it/cnr/isti/hpc/dexter/rest/RestService.java
@@ -214,8 +214,8 @@ public class RestService {
 				double r = rf.getRelatedness(e1list.get(i), e2list.get(j))
 						.getScore();
 				if (r > max) {
-					maxi = i;
-					maxj = j;
+					maxi = e1list.get(i);
+					maxj = e2list.get(j);
 					max = r;
 				}
 			}


### PR DESCRIPTION
In _line 217_ & _line 218_
_maxi_ and _maxj_ get the value of _i_ and _j_, which are the **index value** , but **not** the wiki-id .
It will cause the _line 231_ and _line 233_ could **not** find the Label of wiki entity successfully.