### PR TITLE
Enable specifying a directory to relativize resource paths against

### DIFF
--- a/dexter-core/src/main/java/it/cnr/isti/hpc/dexter/util/DexterParams.java
+++ b/dexter-core/src/main/java/it/cnr/isti/hpc/dexter/util/DexterParams.java
@@ -107,7 +107,7 @@ public class DexterParams {
 		thresholds = new HashMap<String, Float>();
 	}
 
-	private DexterParams(String xmlConfig, String resourceRoot) {
+	private DexterParams(String resourceRoot, String xmlConfig) {
 		this();
 		params = DexterParamsXMLParser.load(xmlConfig);
 

--- a/dexter-core/src/main/java/it/cnr/isti/hpc/dexter/util/DexterParams.java
+++ b/dexter-core/src/main/java/it/cnr/isti/hpc/dexter/util/DexterParams.java
@@ -107,11 +107,11 @@ public class DexterParams {
 		thresholds = new HashMap<String, Float>();
 	}
 
-	private DexterParams(String xmlConfig) {
+	private DexterParams(String xmlConfig, String resourceRoot) {
 		this();
 		params = DexterParamsXMLParser.load(xmlConfig);
 
-		loader = new PluginLoader(new File(params.getLibs().getLib()));
+		loader = new PluginLoader(new File(resourceRoot, params.getLibs().getLib()));
 
 		for (DexterParamsXMLParser.Graph graph : params.getGraphs().getGraphs()) {
 			Map<Direction, String> names = new HashMap<Direction, String>();
@@ -137,7 +137,7 @@ public class DexterParams {
 			thresholds.put(threshold.getName(), threshold.getValue());
 		}
 
-		defaultModel = new File(
+		defaultModel = new File(resourceRoot,
 				models.get(params.getModels().getDefaultModel()));
 
 		graphDir = new File(defaultModel, params.getGraphs().getDir());
@@ -246,8 +246,9 @@ public class DexterParams {
 			String confFile = System.getProperty("conf");
 			if (confFile == null)
 				confFile = "dexter-conf.xml";
+			String resourceRoot = System.getProperty("dexter.resourceRoot", System.getProperty("user.dir"));
 			logger.info("loading configuration from {} ", confFile);
-			dexterParams = new DexterParams(confFile);
+			dexterParams = new DexterParams(confFile, resourceRoot);
 			dexterParams.loadDisambiguators();
 			dexterParams.loadRelatednessFunctions();
 			dexterParams.loadSpotFilters();

--- a/dexter-core/src/main/java/it/cnr/isti/hpc/dexter/util/DexterParams.java
+++ b/dexter-core/src/main/java/it/cnr/isti/hpc/dexter/util/DexterParams.java
@@ -248,7 +248,7 @@ public class DexterParams {
 				confFile = "dexter-conf.xml";
 			String resourceRoot = System.getProperty("dexter.resourceRoot", System.getProperty("user.dir"));
 			logger.info("loading configuration from {} ", confFile);
-			dexterParams = new DexterParams(confFile, resourceRoot);
+			dexterParams = new DexterParams(resourceRoot, confFile);
 			dexterParams.loadDisambiguators();
 			dexterParams.loadRelatednessFunctions();
 			dexterParams.loadSpotFilters();


### PR DESCRIPTION
This change is useful when the desired resources are not in either the working directory or at a constant path. The specific use case that lead to this is using Dexter in an Apache Spark job. Relativizing the paths in the dexter-conf file against wherever Spark downloads the resources greatly simplified my life. To give you an idea of what I mean, our calling code:
```
// Go download this file from S3 and distribute it to the executors
sparkContext.addFile("s3a://.../dexter-resources/", recursive = true)
// And each executor does:
val resourcePath = new File(SparkFiles.get("dexter-resources")).toPath
System.setProperty("conf", resourcePath.resolve("dexter-conf.xml").toString)
System.setProperty("dexter.resourceRoot", resourcePath.toString)
val params = DexterParams.getInstance()
```